### PR TITLE
Zernike: Fix build on Windows: Export symbols for DLL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ aux_source_directory (${CMAKE_CURRENT_SOURCE_DIR}/src SRC_LIST)
 
 # -- Build a shared library
 add_library(${PROJECT_NAME} SHARED ${SRC_LIST})
+target_compile_definitions(${PROJECT_NAME} PRIVATE -DZERNIKE_EXPORTS)
 
 # Define the properties of the library to
 # be built (version and other stuff).

--- a/include/zernike_bits/zernike_global.h
+++ b/include/zernike_bits/zernike_global.h
@@ -1,0 +1,27 @@
+/*! ------------------------------------------------------------------------- *
+* This file is part of the Zernike library. It is thus freely available and  *
+* infinitely modifiable and copyable. As it is with such products, it comes  *
+* with absolutely no warranty. It might even have bugs (!). If so, feel free *
+* to drop a line at the email address above, or visit:                       *
+* https://github.com/valandil/zernike                                        *
+* -------------------------------------------------------------------------- */
+
+#ifndef ZERNIKE_GLOBAL_H
+#define ZERNIKE_GLOBAL_H
+
+#if defined(_WIN32)
+#define ZERNIKE_DECL_EXPORT __declspec(dllexport)
+#define ZERNIKE_DECL_IMPORT __declspec(dllimport)
+#else
+#define ZERNIKE_DECL_EXPORT __attribute__((visibility("default")))
+#define ZERNIKE_DECL_IMPORT __attribute__((visibility("default")))
+#endif
+#ifdef ZERNIKE_EXPORTS
+#define ZERNIKE_API ZERNIKE_DECL_EXPORT
+#elif defined(ZERNIKE_STATIC)
+#define ZERNIKE_API
+#else
+#define ZERNIKE_API ZERNIKE_DECL_IMPORT
+#endif
+
+#endif // ZERNIKE_GLOBAL_H

--- a/include/zernike_bits/zernike_indices.h
+++ b/include/zernike_bits/zernike_indices.h
@@ -14,6 +14,8 @@
 #ifndef ZERNIKE_INDICES_H
 #define ZERNIKE_INDICES_H
 
+#include "zernike_global.h"
+
 #include <iostream>
 
 namespace Zernike {
@@ -30,6 +32,7 @@ namespace Zernike {
 ///   @param[in]  j  Natural single-index.
 ///   @param[out] n  Principal quantum number converted from natural.
 ///   @param[out] m  Angular momentum quantum number converted from natural.
+ZERNIKE_API
 void          NaturalToQuantum(const int     j,
                                      int   & n,
                                      int   & m);
@@ -38,6 +41,7 @@ void          NaturalToQuantum(const int     j,
 ///   @param[in]  n  Principal quantum number to be converted.
 ///   @param[in]  m  Angular momentum quantum number to be converted.
 ///   @retval     j  Natural single-index.
+ZERNIKE_API
 int           QuantumToNatural(const int n,
                                const int m);
 ///@}
@@ -56,6 +60,7 @@ int           QuantumToNatural(const int n,
 ///   @param[in]  j  Noll single-index.
 ///   @param[out] n  Principal quantum number converted from Noll.
 ///   @param[out] m  Angular momentum quantum number converted from Noll.
+ZERNIKE_API
 void         NollToQuantum    (const int   j,
                                      int & n,
                                      int & m);
@@ -68,12 +73,14 @@ void         NollToQuantum    (const int   j,
 //unsigned int QuantumToNoll   (unsigned int n,
 //                              int m);
 
+ZERNIKE_API
 void         PhasicsToQuantum(const int    j,
                                     int  & n,
                                     int  & m);
 
 /// Converts from the OSA/ANSI standard to the quantum values.
 /// http://voi.opt.uh.edu/2000-JRS-standardsforrepotingtheopticalaberrationsofeyes.pdf
+ZERNIKE_API
 void         OSAToQuantum     (const int    j,
                                      int  & n,
                                      int  & m);

--- a/include/zernike_bits/zernike_poly.h
+++ b/include/zernike_bits/zernike_poly.h
@@ -19,6 +19,7 @@ namespace Zernike {
 
 /// Computes the value of a given Zernike polynomial
 /// at a given position in polar coordinates.
+ZERNIKE_API
 double ZernikePolynomial(unsigned int n,
                          int          m,
                          double       r,
@@ -29,6 +30,7 @@ double ZernikePolynomial(unsigned int n,
 /// in whatever linear index convention is specified.
 typedef enum e_IndexConventions {Natural, Noll, Phasics, OSA} IndexConvention;
 typedef void (*LinearToQuantumIndexConversionFunction)(int,int&,int&);
+ZERNIKE_API
 double ZernikeAberrations(std::vector<double> j,
                           double              r,
                           double              theta,

--- a/include/zernike_bits/zernike_radial_poly.h
+++ b/include/zernike_bits/zernike_radial_poly.h
@@ -9,6 +9,8 @@
 #ifndef ZERNIKE_RADIAL_POLY_H
 #define ZERNIKE_RADIAL_POLY_H
 
+#include "zernike_global.h"
+
 #include <cmath>
 #include <iostream>
 #include <vector>
@@ -21,6 +23,7 @@ enum ZernikeEvaluationMethod {direct, recursion};
 
 /// High-level function that serves as an interface to different evaluation
 /// algorithms of the Zernike radial polynomial.
+ZERNIKE_API
 double ZernikeRadialPolynomial(unsigned int n,
                                unsigned int m,
                                double r,


### PR DESCRIPTION
Windows build (VS2015) fails because DLL symbols are not exported. Add the conventional macro to export/import the functions.